### PR TITLE
Fixes #7

### DIFF
--- a/spec/domkm/silk_spec.cljx
+++ b/spec/domkm/silk_spec.cljx
@@ -64,8 +64,16 @@
    (spec/should= (silk/map->URL {:path ["a"] :query {"b" "c"}})
                  (silk/url "/a?b=c"))
    (spec/should= (silk/map->URL {:query {"b" "c"} :path []})
-                 (silk/url "?b=c")))))
+                 (silk/url "?b=c"))))
 
+ (spec/context
+   "toString"
+   (spec/it
+     "Encodes urls"
+     (spec/should= "/users?q=foo"
+                 (.toString (silk/map->URL {:path ["users"] :query {"q" "foo"}})))
+     (spec/should= "/users"
+                   (.toString (silk/map->URL {:path ["users"] :query {"q" nil}}))))))
 
 ;;;; Pattern ;;;;
 
@@ -271,7 +279,8 @@
     (silk/routes [[:id1 [nil nil {:request-method :method}]]
                   (silk/routes [[:id2 [["foo" "bar" :baz]]]])
                   [:id3 [nil {"a" :b}]]
-                  [:id4 [["search"] {"q" (silk/? :q {:q "default"})}]]]))
+                  [:id4 [["search"] {"q" (silk/? :q {:q "default"})}]]
+                  [:id5 [["users"] {"q" (silk/? :q)}]]]))
   (spec/with-all clean-params
     #(dissoc % :domkm.silk/routes :domkm.silk/url :domkm.silk/pattern :domkm.silk/name))
   (spec/it
@@ -311,7 +320,13 @@
                   (silk/arrive @routes "/search?q=foo")))
    (spec/should= {:q "default"}
                  (@clean-params
-                  (silk/arrive @routes "/search"))))
+                  (silk/arrive @routes "/search")))
+   (spec/should= {:q nil}
+                 (@clean-params
+                  (silk/arrive @routes "/users")))
+   (spec/should= {:q "bar"}
+                 (@clean-params
+                  (silk/arrive @routes "/users?q=bar"))))
   (spec/it
    "departs"
    (spec/should= "/foo/bar/bloop"
@@ -321,4 +336,8 @@
    (spec/should= "/search?q=default"
                  (silk/depart @routes :id4))
    (spec/should= "/search?q=foo"
-                 (silk/depart @routes :id4 {:q "foo"})))))
+                 (silk/depart @routes :id4 {:q "foo"}))
+   (spec/should= "/users"
+                 (silk/depart @routes :id5))
+   (spec/should= "/users?q=bar"
+                 (silk/depart @routes :id5 {:q "bar"})))))

--- a/spec/domkm/silk_spec.cljx
+++ b/spec/domkm/silk_spec.cljx
@@ -48,15 +48,18 @@
    (spec/should= (silk/encode-query @query-map) @query-str))
   (spec/it
    "decodes"
-   (spec/should= (silk/decode-query @query-str) @query-map)))
+   (spec/should= (silk/decode-query @query-str) @query-map))
+  (spec/it
+   "empty map produces no query-string"
+   (spec/should= (silk/encode-query {}) "")))
 
  (spec/context
   "parsing"
   (spec/it
    "parses urls"
-   (spec/should= (silk/map->URL {:path ["a"]})
+   (spec/should= (silk/map->URL {:path ["a"] :query {}})
                  (silk/url "/a"))
-   (spec/should= (silk/map->URL {:path ["a"]})
+   (spec/should= (silk/map->URL {:path ["a"] :query {}})
                  (silk/url "/a?"))
    (spec/should= (silk/map->URL {:path ["a"] :query {"b" "c"}})
                  (silk/url "/a?b=c"))
@@ -267,7 +270,8 @@
   (spec/with-all routes
     (silk/routes [[:id1 [nil nil {:request-method :method}]]
                   (silk/routes [[:id2 [["foo" "bar" :baz]]]])
-                  [:id3 [nil {"a" :b}]]]))
+                  [:id3 [nil {"a" :b}]]
+                  [:id4 [["search"] {"q" (silk/? :q {:q "default"})}]]]))
   (spec/with-all clean-params
     #(dissoc % :domkm.silk/routes :domkm.silk/url :domkm.silk/pattern :domkm.silk/name))
   (spec/it
@@ -301,10 +305,20 @@
                   (silk/arrive @routes "/foo/bar/baz")))
    (spec/should= {:b "b"}
                  (@clean-params
-                  (silk/arrive @routes "/?a=b"))))
+                  (silk/arrive @routes "/?a=b")))
+   (spec/should= {:q "foo"}
+                 (@clean-params
+                  (silk/arrive @routes "/search?q=foo")))
+   (spec/should= {:q "default"}
+                 (@clean-params
+                  (silk/arrive @routes "/search"))))
   (spec/it
    "departs"
    (spec/should= "/foo/bar/bloop"
                  (silk/depart @routes :id2 {:baz "bloop"}))
    (spec/should= "/?a=bloop"
-                 (silk/depart @routes :id3 {:b "bloop"})))))
+                 (silk/depart @routes :id3 {:b "bloop"}))
+   (spec/should= "/search?q=default"
+                 (silk/depart @routes :id4))
+   (spec/should= "/search?q=foo"
+                 (silk/depart @routes :id4 {:q "foo"})))))

--- a/src/domkm/silk.cljx
+++ b/src/domkm/silk.cljx
@@ -183,12 +183,10 @@
                        {}))
 
 (defn ^:private unmatch-map [ptrn params]
-  (loop [kvs (seq ptrn)
-         ret (transient {})]
-    (if-let [[k v] (first kvs)]
-      (recur (rest kvs)
-             (assoc! ret k (unmatch v params)))
-      (persistent! ret))))
+  (persistent!
+    (reduce-kv (fn [acc k v]
+                 (assoc! acc k (unmatch v params)))
+               (transient {}) ptrn)))
 
 (extend-type PersistentArrayMap
   Pattern

--- a/src/domkm/silk.cljx
+++ b/src/domkm/silk.cljx
@@ -51,13 +51,14 @@
   "Takes a query string.
   Returns a map of decoded query pairs."
   [^String s]
-  (when-not (str/blank? s)
+  (if-not (str/blank? s)
     (->> (str/split s #"[&;]")
          (reduce (fn [q pair]
                    (let [[k v] (map decode (str/split pair #"="))]
                      (assoc! q k v)))
                  (transient {}))
-         persistent!)))
+         persistent!)
+    {}))
 
 (defrecord URL [scheme user host port path query fragment] ; TODO: scheme, user, host, port, fragment
   Object


### PR DESCRIPTION
Hi,

I took a stab at fixing #7. I'm not perfectly happy how `depart` works with default parameters as it writes the default parameter to the url.

Decode-query now returns empty map for empty string. This way
query string pattern defaults should work even if url has no
query params at all. This shouldn't be problem as encode-url
returns an empty query-string for empty map.