### PR TITLE
Ring handler created by ring-serve should never return nil

### DIFF
--- a/spec/domkm/silk/serve_spec.cljx
+++ b/spec/domkm/silk/serve_spec.cljx
@@ -27,9 +27,9 @@
   (spec/context
    "no match"
    (spec/it
-    "returns nil"
-    (spec/should-be-nil ((serve/ring-handler {:never-route {:path ["nope"]}})
-                         @req))))
+    "calls get-handler with nil route"
+    (spec/should= @req
+                  ((serve/ring-handler {:never-route {:path ["nope"]}} #(fnil identity %)) @req))))
   (spec/context
    "match and `get-handler` is provided"
    (spec/with-all ring-handler (serve/ring-handler

--- a/src/domkm/silk/serve.cljx
+++ b/src/domkm/silk/serve.cljx
@@ -32,9 +32,10 @@
   ([routes get-handler]
    (let [rtes (silk/routes routes)]
      (fn [req]
-       (when-let [params (silk/match rtes (request-map->URL req))]
+       (if-let [params (silk/match rtes (request-map->URL req))]
          ((-> params :domkm.silk/name get-handler)
-          (assoc req :params params)))))))
+          (assoc req :params params))
+         ((get-handler nil) req))))))
 
 
 ;;;; Request Method Pattern ;;;;


### PR DESCRIPTION
Some ring implementation (e.g. `aleph`) do not interpret a `nil` returned by a na route match as a `404`.

This change allows a no route match to call get-handler with nil as route. Implementer is now free to return a custom response.