### PR TITLE
Update README query example to be more realistic

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,13 +111,13 @@ If the second element is a vector, the first and second elements are `assoc`iate
 If the second element is a map, it is left unchanged.
 
 ```clojure
-(silk/url-pattern [["i" "am" "a" "path"] {"i" "am" "a" "query"} {:scheme "https"}])
-;=> {:path ["i" "am" "a" "path"], :query {"i" "am", "a" "query"}, :scheme "https"}
+(silk/url-pattern [["users" "list"] {"filter" :filter "limit" :limit} {:scheme "https"}])
+;=> {:path ["users" "list"], :query {"filter" :filter, "limit" :limit}, :scheme "https"}
 
-(silk/url-pattern {:path ["i" "am" "a" "path"] :query {"i" "am" "a" "query"} :scheme "https"})
-;=> {:path ["i" "am" "a" "path"], :query {"i" "am", "a" "query"}, :scheme "https"}
+(silk/url-pattern {:path ["users" "list"] :query {"filter" :filter "limit" :limit} :scheme "https"})
+;=> {:path ["users" "list"], :query {"filter" :filter, "limit" :limit}, :scheme "https"}
 
-(silk/route [:route-name [["i" "am" "a" "path"] {"i" "am" "a" "query"} {:scheme "https"}]])
+(silk/route [:route-name [["users" "list"] {"filter" :filter "limit" :limit} {:scheme "https"}]])
 ;=> #<Route domkm.silk.Route@6ebe4324>
 ```
 


### PR DESCRIPTION
Instead of generic "i am a path" and "i am a query" sample paths and
queries, let's show something that's closer to how this library will be
used by developers.

Particularly we should be using :symbols in the query map, because it's
unlikely they users would want to only route to a route on an exact
query parameter string match.