### PR TITLE
Avoid overwriting request's params with silk params

### DIFF
--- a/spec/domkm/silk/serve_spec.cljx
+++ b/spec/domkm/silk/serve_spec.cljx
@@ -41,11 +41,14 @@
                   (-> @req
                       (@ring-handler)
                       :params
-                      (select-keys [:username :project])))
-    (spec/should= @req
+                      (select-keys [:username :project]))))
+   (spec/it
+    "won't override existing params in request"
+    (spec/should= "param"
                   (-> @req
+                      (assoc :params {:extra "param"})
                       (@ring-handler)
-                      (dissoc :params)))))
+                      (get-in [:params :extra])))))
   (spec/context
    "match and no `get-handler` provided"
    (spec/it

--- a/src/domkm/silk/serve.cljx
+++ b/src/domkm/silk/serve.cljx
@@ -34,7 +34,7 @@
      (fn [req]
        (if-let [params (silk/match rtes (request-map->URL req))]
          ((-> params :domkm.silk/name get-handler)
-          (merge-with merge req {:params params}))
+          (update req :params merge params))
          ((get-handler nil) req))))))
 
 

--- a/src/domkm/silk/serve.cljx
+++ b/src/domkm/silk/serve.cljx
@@ -34,7 +34,7 @@
      (fn [req]
        (if-let [params (silk/match rtes (request-map->URL req))]
          ((-> params :domkm.silk/name get-handler)
-          (assoc req :params params))
+          (merge-with merge req {:params params}))
          ((get-handler nil) req))))))
 
 


### PR DESCRIPTION
Ring request's `:params` were overwritten by `ring-handler`, which `assoc` its params in the request.

This scenario might be a common one, specially if the user is using something like `ring.middlewares.params.wrap-params`, for example.

This PR makes sure silk `:params` are merged to any possible existing request's `:params`.

I wrote a test for it, let me know if it's enough or if I should test or improve anything else.

Closes #21
